### PR TITLE
Missing semicolon in filters.php

### DIFF
--- a/web/app/mu-plugins/filters.php
+++ b/web/app/mu-plugins/filters.php
@@ -161,7 +161,7 @@ function __is_login_url( string $url ) : bool {
 		return true;
 	}
 
-	return false
+	return false;
 }
 
 /**


### PR DESCRIPTION
This came to light after a customer reached out to Support regarding their recently spun-up Decoupled WordPress site throwing a critical error.

The error shows as:
<img width="1493" alt="image" src="https://github.com/user-attachments/assets/22c3f7f9-1e67-4507-bc6c-7ebbf22aa9ec">